### PR TITLE
設定処理をonResumeに移動

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/java/jp/wings/nikkeibp/omikuji2/Omikuji2Activity.kt
+++ b/app/src/main/java/jp/wings/nikkeibp/omikuji2/Omikuji2Activity.kt
@@ -41,10 +41,10 @@ class Omikuji2Activity : AppCompatActivity(), SensorEventListener {
 
         manager = getSystemService((Context.SENSOR_SERVICE)) as SensorManager
 
-        val pref = PreferenceManager.getDefaultSharedPreferences(this)
-        val value = pref.getBoolean("button", false)
-
-        button.visibility = if (value) View.VISIBLE else View.INVISIBLE
+//        val pref = PreferenceManager.getDefaultSharedPreferences(this)
+//        val value = pref.getBoolean("button", false)
+//
+//        button.visibility = if (value) View.VISIBLE else View.INVISIBLE
         omikujiBox.omikujiView = imageView
 
         // おみくじ棚の準備
@@ -123,6 +123,11 @@ class Omikuji2Activity : AppCompatActivity(), SensorEventListener {
 
     override fun onResume() {
         super.onResume()
+
+        val pref = PreferenceManager.getDefaultSharedPreferences(this)
+        val value = pref.getBoolean("button", false)
+
+        button.visibility = if (value) View.VISIBLE else View.INVISIBLE
 
         val sensor = manager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
         manager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_NORMAL)


### PR DESCRIPTION
設定処理をonResumeに移動してアプリを開いたまま
設定を反映できる使用に変更しました。